### PR TITLE
separate paragraphs again

### DIFF
--- a/dizzydon_source.user.css
+++ b/dizzydon_source.user.css
@@ -341,10 +341,6 @@ quick and dirty overrides of the default stylings. if this CSS seems awful (it i
     .status__content {
         color: primaryFontColor;
     }
-    .reply-indicator__content p,
-    .status__content p {
-        margin-bottom: 0;
-    }
     .status__content__spoiler,
     .status__content.status__content--with-spoiler .status__content__text {
         padding: 10px !important;


### PR DESCRIPTION
right now separate paragraphs (like if you leave an empty line between two pieces of text) will look the same as if they were right after one another. this fixes that.